### PR TITLE
chore(db): drop dead tables (product_pages, matches)

### DIFF
--- a/backend/data/drop_dead_tables.sql
+++ b/backend/data/drop_dead_tables.sql
@@ -1,0 +1,23 @@
+-- Migration: Phase 1 schema cleanup — drop confirmed-dead tables
+--
+-- See docs/schema-redesign.md for the full evaluation. These two tables are the
+-- only "safe now" deletions: both have 0 rows, 0 inbound foreign keys, and no
+-- references in any application code (frontend or backend).
+--
+--   public.product_pages  — superseded by youtube_shorts as the public showcase
+--                           page; never referenced anywhere. 0 rows.
+--   public.matches        — v1 of the matching pipeline; replaced by
+--                           product_creator_matches. Only a coincidental dict
+--                           key "matches" exists in code, no table calls. 0 rows.
+--
+-- Verified pre-drop (2026-05-31): both tables 0 rows, 0 inbound FK constraints.
+--
+-- Status: applied to the live DB via Supabase MCP on 2026-05-31.
+-- Idempotent: uses IF EXISTS.
+
+drop table if exists public.product_pages;
+drop table if exists public.matches;
+
+-- Note: public.matches depends on the match_status enum. The enum is left in
+-- place (harmless if unused); drop separately only if confirmed unused elsewhere:
+--   drop type if exists match_status;


### PR DESCRIPTION
Phase 1 of the cleanup in `docs/schema-redesign.md` (PR #7). Drops two confirmed-dead tables. Already applied to the live DB.

| Table | Rows | Inbound FKs | Code refs | Why dead |
|---|---|---|---|---|
| `product_pages` | 0 | 0 | none | superseded by `youtube_shorts` |
| `matches` | 0 | 0 | none | v1 matching, replaced by `product_creator_matches` |

Both verified empty and FK-free before dropping. Migration: `backend/data/drop_dead_tables.sql` (`DROP ... IF EXISTS`). The `match_status` enum is left in place.

Phases 2-4 remain proposals.